### PR TITLE
Add support of job url param

### DIFF
--- a/cmd/prom-aggregation-gateway/go.mod
+++ b/cmd/prom-aggregation-gateway/go.mod
@@ -1,6 +1,7 @@
 module github.com/weaveworks/prom-aggregation-gateway
 
 require (
+	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_model v0.1.0
 	github.com/prometheus/common v0.8.0

--- a/cmd/prom-aggregation-gateway/go.sum
+++ b/cmd/prom-aggregation-gateway/go.sum
@@ -17,6 +17,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/cmd/prom-aggregation-gateway/main.go
+++ b/cmd/prom-aggregation-gateway/main.go
@@ -14,6 +14,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/route"
 )
 
 func lablesLessThan(a, b []*dto.LabelPair) bool {
@@ -201,7 +202,9 @@ func (a *aggate) parseAndMerge(r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	return a.merge(inFamilies)
+
+	job := route.Param(r.Context(), "job")
+	return a.merge(inFamilies, job)
 }
 
 func (a *aggate) parse(r *http.Request) (map[string]*dto.MetricFamily, error) {
@@ -231,7 +234,7 @@ func (a *aggate) parse(r *http.Request) (map[string]*dto.MetricFamily, error) {
 	return parser.TextToMetricFamilies(r.Body)
 }
 
-func (a *aggate) merge(inFamilies map[string]*dto.MetricFamily) error {
+func (a *aggate) merge(inFamilies map[string]*dto.MetricFamily, job string) error {
 	a.familiesLock.Lock()
 	defer a.familiesLock.Unlock()
 	for name, family := range inFamilies {
@@ -245,6 +248,11 @@ func (a *aggate) merge(inFamilies map[string]*dto.MetricFamily) error {
 
 		// Sort labels in case source sends them inconsistently
 		for _, m := range family.Metric {
+			if job != "" {
+				jobName := "job"
+				jobLabel := dto.LabelPair{Name: &jobName, Value: &job}
+				m.Label = append(m.Label, &jobLabel)
+			}
 			sort.Sort(byName(m.Label))
 		}
 
@@ -294,18 +302,22 @@ func (a *aggate) handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	listen := flag.String("listen", ":80", "Address and port to listen on.")
 	cors := flag.String("cors", "*", "The 'Access-Control-Allow-Origin' value to be returned.")
-	pushPath := flag.String("push-path", "/metrics/", "HTTP path to accept pushed metrics.")
+	pushPath := flag.String("push-path", "/metrics/job/:job", "HTTP path to accept pushed metrics.")
 	flag.Parse()
 
 	a := newAggate()
-	http.HandleFunc("/metrics", a.handler)
-	http.HandleFunc(*pushPath, func(w http.ResponseWriter, r *http.Request) {
+
+	r := route.New()
+	r.Get("/metrics", a.handler)
+	pushHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", *cors)
 		if err := a.parseAndMerge(r); err != nil {
 			log.Println(err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-	})
-	log.Fatal(http.ListenAndServe(*listen, nil))
+	}
+	r.Post(*pushPath, pushHandler)
+	r.Put(*pushPath, pushHandler)
+	log.Fatal(http.ListenAndServe(*listen, r))
 }

--- a/cmd/prom-aggregation-gateway/main_test.go
+++ b/cmd/prom-aggregation-gateway/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/route"
 )
 
 const (
@@ -119,9 +120,9 @@ ui_external_lib_loaded{name="mixpanel",loaded="true"} 1
 `
 	gaugeOutput = `# HELP ui_external_lib_loaded A gauge with entries in un-sorted order
 # TYPE ui_external_lib_loaded gauge
-ui_external_lib_loaded{loaded="true",name="Intercom"} 2
-ui_external_lib_loaded{loaded="true",name="ga"} 2
-ui_external_lib_loaded{loaded="true",name="mixpanel"} 2
+ui_external_lib_loaded{job="dev-project",loaded="true",name="Intercom"} 2
+ui_external_lib_loaded{job="dev-project",loaded="true",name="ga"} 2
+ui_external_lib_loaded{job="dev-project",loaded="true",name="mixpanel"} 2
 `
 	duplicateLabels = `
 # HELP ui_external_lib_loaded Test with duplicate values
@@ -179,7 +180,7 @@ func convertToProtobufFormat(t *testing.T, metrics string) io.Reader {
 	return buf
 }
 
-func createPushRequest(t *testing.T, metrics string, contentType string) *http.Request {
+func createPushRequest(t *testing.T, metrics string, contentType string, job string) *http.Request {
 	var data io.Reader
 	if contentType == contentTypeProtobuf {
 		data = convertToProtobufFormat(t, metrics)
@@ -191,34 +192,48 @@ func createPushRequest(t *testing.T, metrics string, contentType string) *http.R
 	}
 	req := httptest.NewRequest("POST", "http://example.com/bar", data)
 	req.Header.Set("Content-Type", contentType)
+
+
+	if job != "" {
+		params := map[string]string{
+			"job": job,
+		}
+
+		ctx := req.Context()
+		for p, v := range params {
+			ctx = route.WithParam(ctx, p, v)
+		}
+		req = req.WithContext(ctx)
+	}
 	return req
 }
 
 func TestAggate(t *testing.T) {
 	for _, c := range []struct {
+		job  string
 		a, b string
 		want string
 		err1 error
 		err2 error
 	}{
-		{gaugeInput, gaugeInput, gaugeOutput, nil, nil},
-		{in1, in2, want, nil, nil},
-		{multilabel1, multilabel2, multilabelResult, nil, nil},
-		{labelFields1, labelFields2, labelFieldResult, nil, nil},
-		{duplicateLabels, "", "", fmt.Errorf("%s", duplicateError), nil},
-		{reorderedLabels1, reorderedLabels2, reorderedLabelsResult, nil, nil},
-		{summaryInput, summaryInput, summaryDiscardedOutput, nil, nil},
+		{"dev-project", gaugeInput, gaugeInput, gaugeOutput, nil, nil},
+		{"", in1, in2, want, nil, nil},
+		{"", multilabel1, multilabel2, multilabelResult, nil, nil},
+		{"", labelFields1, labelFields2, labelFieldResult, nil, nil},
+		{"", duplicateLabels, "", "", fmt.Errorf("%s", duplicateError), nil},
+		{"", reorderedLabels1, reorderedLabels2, reorderedLabelsResult, nil, nil},
+		{"", summaryInput, summaryInput, summaryDiscardedOutput, nil, nil},
 	} {
 		for _, contentType := range []string{contentTypeText, contentTypeProtobuf} {
 			a := newAggate()
-			if err := a.parseAndMerge(createPushRequest(t, c.a, contentType)); err != nil {
+			if err := a.parseAndMerge(createPushRequest(t, c.a, contentType, c.job)); err != nil {
 				if c.err1 == nil {
 					t.Fatalf("Unexpected error: %s", err)
 				} else if c.err1.Error() != err.Error() {
 					t.Fatalf("Expected %s, got %s", c.err1, err)
 				}
 			}
-			if err := a.parseAndMerge(createPushRequest(t, c.b, contentType)); err != c.err2 {
+			if err := a.parseAndMerge(createPushRequest(t, c.b, contentType, c.job)); err != c.err2 {
 				t.Fatalf("Expected %s, got %s", c.err2, err)
 			}
 


### PR DESCRIPTION
Adding the same support of job label from URL param as the [Push Gateway library](https://github.com/prometheus/pushgateway/blob/master/README.md#command-line): 

`echo "some_metric 3.14" | curl --data-binary @- http://localhost:9091/metrics/job/some_job`

will result in the following metric generation:

`some_metric{instance="",job="some_job"} 3.14`
